### PR TITLE
Include py files, make sure pypi publishing works (via test pypi)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
   - maturin build --interpreter $PYVER
   - |
     if [[ $TRAVIS_TAG ]] && [ -n "$PYPI_TOKEN" ]; then
-       maturin publish --no-sdist --username __token__ --password "$PYPI_TOKEN"
+       docker run --rm -v $(pwd):/io konstin2/maturin publish --no-sdist --username __token__ --password "$PYPI_TOKEN"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 jobs:
   include:
-    - os: linux
+    - python: 3.7
+      os: linux
       sudo: required
       services:
         - docker
@@ -21,5 +22,5 @@ script:
   - maturin build --interpreter $PYVER
   - |
     if [[ $TRAVIS_TAG ]] && [ -n "$PYPI_TOKEN" ]; then
-       maturin publish --username __token__ --password "$PYPI_TOKEN"
+       maturin publish --no-sdist --username __token__ --password "$PYPI_TOKEN"
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "svm2csr_rs"
-version = "0.0.1"
+name = "svm2csr"
+version = "0.0.2"
 authors = ["Vladimir Feinberg <vladimir.feinberg@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "py_svm2csr_rs"
+name = "svm2csr"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ from svm2csr import load
 pip install svm2csr
 ```
 
-Note this package is only available for pythons, operating systems, and machine architecture targets I can build wheels for. Right now, that's:
+Note this package is only available for pythons, operating systems, and machine architecture targets I can build wheels for. Right now, that makes it linux-only.
 
-* `cp36m, manylinux2010, x86_64`
+* `cp36-cp39, manylinux2010, x86_64`
 
 # Unsupported Features
 
@@ -41,6 +41,8 @@ Note this package is only available for pythons, operating systems, and machine 
 * writing SVMlight files
 * `n_features` option
 * `zero_based` option
+* graceful client `multiprocessing`
+* mac and windows wheels
 
 All of these are fixable (even stream reading with parallel bridge). Let me know if you'd like to make PR.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ from svm2csr import load
 pip install svm2csr
 ```
 
+Note this package is only available for pythons, operating systems, and machine architecture targets I can build wheels for. Right now, that's:
+
+* `cp36m, manylinux2010, x86_64`
+
 # Unsupported Features
 
 * `dtype` (currently only doubles supported)
@@ -37,7 +41,6 @@ pip install svm2csr
 * writing SVMlight files
 * `n_features` option
 * `zero_based` option
-* windows, mac, and non-Travis-default python wheels
 
 All of these are fixable (even stream reading with parallel bridge). Let me know if you'd like to make PR.
 
@@ -61,9 +64,15 @@ maturin develop # create py bindings for rust code
 pytest # test python bindings
 ```
 
-TODO cool little travis build bubbles
-
 [![travis build](https://travis-ci.org/vlad17/svm2csr.svg?branch=master](https://travis-ci.org/vlad17/svm2csr)
 
+# Publishing
 
+Maturin doesn't prepare a `setup.py` when publishing. For this reason, a source distribution doesn't make sense, as a client machine's `pip` would not know how to install this package. For this reason, only wheels are published.
 
+A new set of wheels can be built and published for supported OSes and pythons with the following steps for a repository administrator:
+
+1. Fetch the most recent master.
+1. Bump the version in `Cargo.toml` appropriately if needed (else wheel names will clash with previous ones in pypi, though PRs should be bumping this already). Commit these changes.
+1. Tag the release. `git tag -a -m "v<CURRENT VERSION>"`
+1. Push to github, triggering a Travis build that tests, packages, and uploads to pypi. `git push --follow-tags`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["maturin"]
-build-backend = "maturin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,8 @@ use pyo3::wrap_pyfunction;
 ///
 /// Not intended to be called directly. Instead, see :func:`~svm2csr.load_svmlight_file`.
 #[pymodule]
-fn py_svm2csr_rs(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(load, m)?)?;
+fn svm2csr(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(rs_load, m)?)?;
 
     Ok(())
 }
@@ -17,7 +17,7 @@ fn py_svm2csr_rs(_py: Python, m: &PyModule) -> PyResult<()> {
 /// Returns a three-tuple of bytes containing (data, indices, indptr) with types
 /// (f8, u8, u8) in native endianness.
 #[pyfunction]
-fn load(py: Python, _fname: String) -> PyResult<PyObject> {
+fn rs_load(py: Python, _fname: String) -> PyResult<PyObject> {
     let data = vec![1.0f64, 10.0f64, 0.1f64];
     let indices = vec![1u64, 1u64, 3u64];
     let indptr = vec![0u64, 1, 3];

--- a/svm2csr/__init__.py
+++ b/svm2csr/__init__.py
@@ -1,1 +1,2 @@
 from .load import load_svmlight_file
+from .svm2csr import rs_load

--- a/svm2csr/load.py
+++ b/svm2csr/load.py
@@ -5,7 +5,7 @@ SVMlight loading API.
 import numpy as np
 import scipy.sparse as sps
 
-import py_svm2csr_rs
+from .svm2csr import rs_load
 
 def load_svmlight_file(fname):
     """
@@ -13,7 +13,7 @@ def load_svmlight_file(fname):
 
     fname (str): the file name of the file to load.
     """
-    data, indices, indptr = py_svm2csr_rs.load(fname)
+    data, indices, indptr = rs_load(fname)
     print(data, indices, indptr)
 
     data = np.frombuffer(data, dtype=np.float64)


### PR DESCRIPTION
Maturing relies on identically-named rust/py packages to make sure everything is packaged together. This fixes the naming issue.

I also switch travis builds to use the maturin manylinux build container, which gets us Linux distribution for py3.6 to 3.9